### PR TITLE
Fix id handling

### DIFF
--- a/lib/json-schema/schema.rb
+++ b/lib/json-schema/schema.rb
@@ -48,8 +48,7 @@ module JSON
     private
 
     def generate_schema_uri(uri)
-      schema_uri = uri.clone
-      schema_uri.fragment = ''
+      schema_uri = uri.merge('#') # Drop fragment if present
       return schema_uri unless @schema['id'] && @schema['id'].kind_of?(String)
 
       id_uri = URI.parse(@schema['id'])

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -499,8 +499,12 @@ module JSON
       end
     end
 
-    def fake_uuid schema
+    def fake_uuid(schema)
       @@fake_uuid_generator.call(schema)
+    end
+
+    def fake_uri_for_schema(schema)
+      URI::Generic.build(:scheme => "urn", :opaque => "uuid:#{fake_uuid(schema)}")
     end
 
     def schema_to_list(schema)
@@ -516,7 +520,7 @@ module JSON
       if schema.is_a?(String)
         begin
           # Build a fake URI for this
-          schema_uri = URI.parse(fake_uuid(schema))
+          schema_uri = fake_uri_for_schema(schema)
           schema = JSON::Validator.parse(schema)
           if @options[:list] && @options[:fragment].nil?
             schema = schema_to_list(schema)
@@ -537,7 +541,7 @@ module JSON
             schema = Validator.schemas[schema_uri.to_s]
             if @options[:list] && @options[:fragment].nil?
               schema = schema_to_list(schema.schema)
-              schema_uri = URI.parse(fake_uuid(serialize(schema)))
+              schema_uri = fake_uri_for_schema(serialize(schema))
               schema = JSON::Schema.new(schema, schema_uri, @options[:version])
               Validator.add_schema(schema)
             end
@@ -548,7 +552,7 @@ module JSON
         if @options[:list] && @options[:fragment].nil?
           schema = schema_to_list(schema)
         end
-        schema_uri = URI.parse(fake_uuid(serialize(schema)))
+        schema_uri = fake_uri_for_schema(serialize(schema))
         schema = JSON::Schema.new(schema,schema_uri,@options[:version])
         Validator.add_schema(schema)
       else

--- a/test/test_bad_schema_ref.rb
+++ b/test/test_bad_schema_ref.rb
@@ -16,12 +16,12 @@ class BadSchemaRefTest < Minitest::Test
     schema = {
       "$schema" => "http://json-schema.org/draft-04/schema#",
       "type" => "array",
-      "items" => { "$ref" => "../google.json"}
+      "items" => { "$ref" => "{bad-scheme}://foo.com"}
     }
 
     data = [1,2,3]
-    assert_raises(URI::BadURIError) do
-      JSON::Validator.validate(schema,data)
+    assert_raises(URI::InvalidURIError) do
+      JSON::Validator.validate(schema, data)
     end
   end
 

--- a/test/test_list_option.rb
+++ b/test/test_list_option.rb
@@ -8,7 +8,7 @@ class ListOptionTest < Minitest::Test
       "properties" => { "a" => { "type" => "integer" } }
     }
 
-    uri = URI.parse('http://example.com/item')
+    uri = URI.parse('http://example.com/item#')
     schema = JSON::Schema.new(schema_hash, uri)
     JSON::Validator.add_schema(schema)
 

--- a/test/test_schema_validation.rb
+++ b/test/test_schema_validation.rb
@@ -36,6 +36,14 @@ class JSONSchemaValidation < Minitest::Test
     }
   end
 
+  def valid_schema_v4_with_fragment_id
+    valid_schema_v4.merge("id" => "#/foo")
+  end
+
+  def valid_schema_v4_with_absolute_uri_id
+    valid_schema_v4.merge("id" => "http://www.example.invalid/#/foo")
+  end
+
   def invalid_schema_v4
     {
       "$schema" => "http://json-schema.org/draft-04/schema#",
@@ -142,6 +150,8 @@ class JSONSchemaValidation < Minitest::Test
     data = {"b" => {"a" => 5}}
     assert(JSON::Validator.validate(valid_schema_v4,data,:validate_schema => true, :version => :draft4))
     assert(!JSON::Validator.validate(invalid_schema_v4,data,:validate_schema => true, :version => :draft4))
+    assert(JSON::Validator.validate(valid_schema_v4_with_fragment_id,data,:validate_schema => true, :version => :draft4))
+    assert(JSON::Validator.validate(valid_schema_v4_with_absolute_uri_id,data,:validate_schema => true, :version => :draft4))
   end
 
   def test_validate_just_schema_draft04


### PR DESCRIPTION
This introduces a few refactors and changes which fixes handling of what validates as a valid Draft 4 schema:

```
{
  "id": "#/example",
  "type": "integer",
  "oneOf": [
    {"$ref": "#/definitions/foo"},
    {"$ref": "#/definitions/bar"}],
  "definitions": {
    "foo": {
      "type": "integer",
      "maximum": 1000
    },
    "bar": {
      "type": "integer",
      "minimum": 2000,
      "maximum": 3000
    }
  }
}
```

`json-schema` validation to show it's a valid schema:

```
irb(main):005:0> require 'json-schema'
=> true
irb(main):006:0> puts valid_schema
{
  "id": "#/example",
  "type": "integer",
  "oneOf": [
    {"$ref": "#/definitions/foo"},
    {"$ref": "#/definitions/bar"}],
  "definitions": {
    "foo": {
      "type": "integer",
      "maximum": 1000
    },
    "bar": {
      "type": "integer",
      "minimum": 2000,
      "maximum": 3000
    }
  }
}
=> nil
irb(main):007:0> JSON::Validator.fully_validate_schema(valid_schema, version: :draft4)
=> []
```

It also validates against the Java [`json-schema-validator`](http://json-schema-validator.herokuapp.com/index.jsp).

Before these changes, trying to use the provided example schema would result in an exception:

```
/usr/local/opt/rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/common.rb:176:in `split': bad URI(is not URI?): {"id"=>"#/example", "type"=>"integer", "oneOf"=>[{"$ref"=>"#/definitions/foo"}, {"$ref"=>"#/definitions/bar"}], "definitions"=>{"foo"=>{"type"=>"integer", "maximum"=>1000}, "bar"=>{"type"=>"integer", "minimum"=>2000, "maximum"=>3000}}} (URI::InvalidURIError)
    from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/common.rb:211:in `parse'
    from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/2.1.0/uri/common.rb:747:in `parse'
    from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/json-schema-2.4.1/lib/json-schema/validator.rb:584:in `normalized_uri'
    from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/json-schema-2.4.1/lib/json-schema/validator.rb:528:in `rescue in initialize_schema'
    from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/json-schema-2.4.1/lib/json-schema/validator.rb:517:in `initialize_schema'
    from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/json-schema-2.4.1/lib/json-schema/validator.rb:47:in `block in initialize'
    from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/json-schema-2.4.1/lib/json-schema/validator.rb:47:in `synchronize'
    from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/json-schema-2.4.1/lib/json-schema/validator.rb:47:in `initialize'
    from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/json-schema-2.4.1/lib/json-schema/validator.rb:294:in `new'
    from /usr/local/opt/rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/json-schema-2.4.1/lib/json-schema/validator.rb:294:in `fully_validate'
    from ./bin/json-validator:19:in `<main>'
```

This PR refactors some things and fixes the issue.
