### PR TITLE
Codeclimate test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ matrix:
   include:
     - rvm: "2.2"
       gemfile: "gemfiles/Gemfile.uuidtools.x"
+env:
+  global:
+    - CODECLIMATE_REPO_TOKEN=f06667b968b44c85d8bacf7321b323574188f6771d0d3534e0cb9ddaade23dd7

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Changes in json-schema 3.0
 
+* Made travis builds send code coverage data to code climate
 * Support for `multi_json` and `yajl-ruby` have been dropped; the standard `json` library,
   available on all common Ruby implementations, is always used.
 * Support for Ruby 1.8 has been removed; a Ruby 1.9+ compatible runtime is now required.

--- a/README.textile
+++ b/README.textile
@@ -1,5 +1,6 @@
 !https://travis-ci.org/ruby-json-schema/json-schema.svg?branch=master!:https://travis-ci.org/ruby-json-schema/json-schema
 !https://codeclimate.com/github/ruby-json-schema/json-schema/badges/gpa.svg!:https://codeclimate.com/github/ruby-json-schema/json-schema
+!https://codeclimate.com/github/ruby-json-schema/json-schema/badges/coverage.svg!:https://codeclimate.com/github/ruby-json-schema/json-schema
 
 h1. Ruby JSON Schema Validator
 

--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", '~> 5.0'
   s.add_development_dependency "webmock"
   s.add_development_dependency "bundler"
+  s.add_development_dependency "codeclimate-test-reporter"
 
   s.add_runtime_dependency "addressable", '~> 2.3.7'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,17 @@
+if ENV['CI'].to_s == 'true'
+  require "codeclimate-test-reporter"
+  CodeClimate::TestReporter.start
+end
+
 require 'minitest/autorun'
 require 'webmock/minitest'
+
+WebMock.disable_net_connect!
+
+Minitest.after_run do
+  # make sure webmock does not prevent posting to code climate
+  WebMock.allow_net_connect!
+end
 
 $:.unshift(File.expand_path('../../lib', __FILE__))
 require 'json-schema'


### PR DESCRIPTION
This will start sending test coverage data to code climate, so you can see it inline, alongside code quality metrics.

It's set to merge into the 3.x branch, because codeclimate requires multijson on every build, making it impossible to test json-schema without multijson. But in 3.x we don't use multijson, so there's no side-effect.
