### PR TITLE
Made sure we require timeout before using it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Rescue URI error when initializing a data string that contains a colon
 - Fragments with an odd number of components no longer raise an `undefined method `validate'`
   error
+- Loading data from a url no longer raises a "uninitialized constant JSON::Validator::Timeout" error
 
 ## [2.8.0] - 2017-02-07
 

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -4,6 +4,7 @@ require 'bigdecimal'
 require 'digest/sha1'
 require 'date'
 require 'thread'
+require 'timeout'
 require 'yaml'
 
 require 'json-schema/schema/reader'


### PR DESCRIPTION
If you run `JSON::Validator.validate(metaschema, "http://a/%%30%30")`
then you'll see the error "uninitialized constant Timeout". This is
happening because we reference `Timeout` in `Validator` without
requiring it.

Interestingly I can't reproduce this error in the test suite because
something else (probably webmock?) is already requiring timeout for
us, and this error does not occur.

Fixes #384