### PR TITLE
Always return duplicates from JSON::Util::URI.parse

### DIFF
--- a/lib/json-schema/util/uri.rb
+++ b/lib/json-schema/util/uri.rb
@@ -65,12 +65,8 @@ module JSON
           return uri.dup
         else
           @parse_cache ||= {}
-          parsed_uri = @parse_cache[uri]
-          if parsed_uri
-            parsed_uri.dup
-          else
-            @parse_cache[uri] = Addressable::URI.parse(uri)
-          end
+          @parse_cache[uri] ||= Addressable::URI.parse(uri)
+          @parse_cache[uri].dup
         end
       rescue Addressable::URI::InvalidURIError => e
         raise JSON::Schema::UriError.new(e.message)


### PR DESCRIPTION
Some callsides seem to modify the returned URI instance, messing up
the cache. This can lead to the wrong schema fragment being used
when multiple schemas with overlapping fragment paths are loaded
and validated against.

Unfortunately I didn't manage to construct an integrative test case
and I'm not sure how much worth something would be that just checks this
method is indeed returning duplicates in any case