### PR TITLE
Force json version to 2.2.0 for ruby lower than 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "json", ">= 1.7", :platforms => :mri_19
+gem "json", (RUBY_VERSION < '2.3' ? "<= 2.2.0" : ">= 1.7"), :platforms => :mri_19
 gem 'simplecov', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "json", (RUBY_VERSION < '2.3' ? "<= 2.2.0" : ">= 1.7"), :platforms => :mri_19
+gem "json", (RUBY_VERSION < '2.3' ? "<= 2.2.0" : ">= 1.7"), :platforms => [:mri_19, :jruby]
 gem 'simplecov', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "json", (RUBY_VERSION < '2.3' ? "<= 2.2.0" : ">= 1.7"), :platforms => [:mri_19, :jruby]
+gem "json", (RUBY_VERSION < '2.0' ? "<= 2.2.0" : ">= 1.7"), :platforms => [:mri_19, :jruby]
 gem 'simplecov', :require => false


### PR DESCRIPTION
Json 2.3.0 uses some new features which are only present in ruby 2.0 and above.
I have updated the Gemfile to prevent users of ruby 1.9 to install the newer json library and run in to runtime issues