### PR TITLE
Improve travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: "ruby"
+cache: bundler
 
 rvm:
   - "1.9"
@@ -12,9 +13,6 @@ rvm:
   - "jruby-9.1"
 
 sudo: false
-
-install:
-  - bundle install --retry=3
 
 matrix:
   include:


### PR DESCRIPTION
By default travis performs the bundle install.

I have also cached the bundle install

More information 
https://docs.travis-ci.com/user/languages/ruby/#dependency-management