### PR TITLE
Allow resolution of fragments with escaped parts

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -73,7 +73,7 @@ module JSON
 
     def schema_from_fragment(base_schema, fragment)
       schema_uri = base_schema.uri
-      fragments = fragment.split("/")
+      fragments = fragment.split("/").map { |f| f.gsub('~0', '~').gsub('~1', '/') }
 
       # ensure the first element was a hash, per the fragment spec
       if fragments.shift != "#"

--- a/test/fragment_resolution_test.rb
+++ b/test/fragment_resolution_test.rb
@@ -80,4 +80,21 @@ class FragmentResolutionTest < Minitest::Test
     assert_valid schema, 5, :fragment => "#/properties/a/anyOf/0"
     refute_valid schema, 5, :fragment => "#/properties/a/anyOf/1"
   end
+
+  def test_fragment_with_escape_sequences_resolution
+    schema = {
+      "content" => {
+        "application/json" => {
+          "type" => "object",
+          "required" => ["a"],
+          "properties" => {
+            "a" => {"type" => "integer"}
+          }
+        }
+      }
+    }
+
+    assert_valid schema, {"a" => 1}, :fragment => "#/content/application~1json"
+    refute_valid schema, {}, :fragment => "#/content/application~1json"
+  end
 end


### PR DESCRIPTION
This fix allows to validate against schema fragments containing `~0` and `~1` escape sequences in their path (e. g. useful when validating parts of OpenAPI schema).