### PR TITLE
Call URI.open directly

### DIFF
--- a/lib/json-schema/schema/reader.rb
+++ b/lib/json-schema/schema/reader.rb
@@ -118,7 +118,7 @@ module JSON
 
       def read_uri(uri)
         if accept_uri?(uri)
-          open(uri.to_s).read
+          URI.open(uri.to_s).read
         else
           raise JSON::Schema::ReadRefused.new(uri.to_s, :uri)
         end

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -593,7 +593,7 @@ module JSON
       uri = Util::URI.normalized_uri(uri) if uri.is_a?(String)
       if uri.absolute? && Util::URI::SUPPORTED_PROTOCOLS.include?(uri.scheme)
         begin
-          open(uri.to_s).read
+          URI.open(uri.to_s).read
         rescue OpenURI::HTTPError, Timeout::Error => e
           raise JSON::Schema::JsonLoadError, e.message
         end


### PR DESCRIPTION
Removes warning: "calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open"