### PR TITLE
Call URI.open directly / Drop Ruby 2.4 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "2.4"
           - ruby: "2.5"
             coverage: "yes"
     env:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ default**, so schemas that do not declare a validator using the `$schema`
 keyword will use Draft-04 now instead of Draft-03. This is the reason for the
 major version upgrade.
 
+Version 3.0.0 Upgrade Notes
+---------------------------
+
+All individual changes are documented in the CHANGELOG.md. The biggest change
+is that the new version only supports Ruby 2.5 and newer. Take a look into the
+gemspec file to see the currently supported Ruby version and also
+`.github/workflows/test.yml` to see the Ruby versions we test on.
+
 Installation
 ------------
 

--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir[ "lib/**/*", "resources/*.json" ]
   s.require_path = "lib"
   s.extra_rdoc_files = ["README.md","LICENSE.md"]
-  s.required_ruby_version = ">= 1.9"
+  s.required_ruby_version = ">= 2.5"
   s.license = "MIT"
   s.required_rubygems_version = ">= 1.8"
 

--- a/lib/json-schema/schema/reader.rb
+++ b/lib/json-schema/schema/reader.rb
@@ -118,7 +118,7 @@ module JSON
 
       def read_uri(uri)
         if accept_uri?(uri)
-          open(uri.to_s).read
+          URI.open(uri.to_s).read
         else
           raise JSON::Schema::ReadRefused.new(uri.to_s, :uri)
         end

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -593,7 +593,7 @@ module JSON
       uri = Util::URI.normalized_uri(uri) if uri.is_a?(String)
       if uri.absolute? && Util::URI::SUPPORTED_PROTOCOLS.include?(uri.scheme)
         begin
-          open(uri.to_s).read
+          URI.open(uri.to_s).read
         rescue OpenURI::HTTPError, Timeout::Error => e
           raise JSON::Schema::JsonLoadError, e.message
         end


### PR DESCRIPTION
Removes warning: "calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open"