### PR TITLE
Add `allPropertiesRequired` and `noAdditionalProperties` options

### DIFF
--- a/lib/json-schema/attributes/properties.rb
+++ b/lib/json-schema/attributes/properties.rb
@@ -4,7 +4,7 @@ module JSON
   class Schema
     class PropertiesAttribute < Attribute
       def self.required?(schema, options)
-        schema.fetch('required') { options[:strict] }
+        schema.fetch('required') { options[:allPropertiesRequired] }
       end
 
       def self.validate(current_schema, data, fragments, processor, validator, options = {})
@@ -33,8 +33,8 @@ module JSON
           end
         end
 
-        # When strict is true, ensure no undefined properties exist in the data
-        return unless options[:strict] == true && !schema.key?('additionalProperties')
+        # When noAdditionalProperties is true, ensure no undefined properties exist in the data
+        return unless options[:noAdditionalProperties] == true && !schema.key?('additionalProperties')
 
         diff = data.select do |k, v|
           k = k.to_s

--- a/lib/json-schema/attributes/properties_v4.rb
+++ b/lib/json-schema/attributes/properties_v4.rb
@@ -6,7 +6,7 @@ module JSON
       # draft4 relies on its own RequiredAttribute validation at a higher level, rather than
       # as an attribute of individual properties.
       def self.required?(schema, options)
-        options[:strict] == true
+        options[:allPropertiesRequired] == true
       end
     end
   end

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -27,6 +27,8 @@ module JSON
       insert_defaults: false,
       clear_cache: false,
       strict: false,
+      allPropertiesRequired: false,
+      noAdditionalProperties: false,
       parse_data: true,
     }
     @@validators = {}
@@ -45,7 +47,13 @@ module JSON
 
       @validation_options = @options[:record_errors] ? { record_errors: true } : {}
       @validation_options[:insert_defaults] = true if @options[:insert_defaults]
-      @validation_options[:strict] = true if @options[:strict] == true
+      if @options[:strict] == true
+        @validation_options[:allPropertiesRequired] = true
+        @validation_options[:noAdditionalProperties] = true
+      else
+        @validation_options[:allPropertiesRequired] = true if @options[:allPropertiesRequired]
+        @validation_options[:noAdditionalProperties] = true if @options[:noAdditionalProperties]
+      end
       @validation_options[:clear_cache] = true if !@@cache_schemas || @options[:clear_cache]
 
       @@mutex.synchronize { @base_schema = initialize_schema(schema_data, configured_validator) }

--- a/test/draft3_test.rb
+++ b/test/draft3_test.rb
@@ -131,18 +131,28 @@ class Draft3Test < Minitest::Test
 
     data = { 'a' => 'a' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'b' => 'b' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b' }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 'c' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 3 }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
   end
 
   def test_strict_properties_pattern_props
@@ -157,24 +167,38 @@ class Draft3Test < Minitest::Test
 
     data = { 'a' => 'a' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'b' => 'b' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b' }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 'c' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 3 }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', '23 taco' => 3 }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', '23 taco' => 'cheese' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
   end
 
   def test_disallow

--- a/test/draft4_test.rb
+++ b/test/draft4_test.rb
@@ -2,89 +2,7 @@
 
 require File.expand_path('../support/test_helper', __FILE__)
 
-class Draft4Test < Minitest::Test
-  def validation_errors(schema, data, options)
-    super(schema, data, version: :draft4)
-  end
-
-  def exclusive_minimum
-    { 'exclusiveMinimum' => true }
-  end
-
-  def exclusive_maximum
-    { 'exclusiveMaximum' => true }
-  end
-
-  def ipv4_format
-    'ipv4'
-  end
-
-  include ArrayValidation::ItemsTests
-  include ArrayValidation::AdditionalItemsTests
-  include ArrayValidation::UniqueItemsTests
-
-  include EnumValidation::General
-  include EnumValidation::V3_V4
-
-  include NumberValidation::MinMaxTests
-  include NumberValidation::MultipleOfTests
-
-  include ObjectValidation::AdditionalPropertiesTests
-  include ObjectValidation::PatternPropertiesTests
-
-  include StrictValidation
-
-  include StringValidation::ValueTests
-  include StringValidation::FormatTests
-
-  include TypeValidation::SimpleTypeTests
-
-  def test_required
-    # Set up the default datatype
-    schema = {
-      '$schema' => 'http://json-schema.org/draft-04/schema#',
-      'required' => ['a'],
-      'properties' => {
-        'a' => {},
-      },
-    }
-    data = {}
-
-    refute_valid schema, data
-    data['a'] = 'Hello'
-    assert_valid schema, data
-
-    schema = {
-      '$schema' => 'http://json-schema.org/draft-04/schema#',
-      'properties' => {
-        'a' => { 'type' => 'integer' },
-      },
-    }
-
-    data = {}
-    assert_valid schema, data
-  end
-
-  def test_min_properties
-    schema = { 'minProperties' => 2 }
-
-    assert_valid schema, { 'a' => 1, 'b' => 2 }
-    assert_valid schema, { 'a' => 1, 'b' => 2, 'c' => 3 }
-
-    refute_valid schema, { 'a' => 1 }
-    refute_valid schema, {}
-  end
-
-  def test_max_properties
-    schema = { 'maxProperties' => 2 }
-
-    assert_valid schema, { 'a' => 1, 'b' => 2 }
-    assert_valid schema, { 'a' => 1 }
-    assert_valid schema, {}
-
-    refute_valid schema, { 'a' => 1, 'b' => 2, 'c' => 3 }
-  end
-
+module StrictValidationV4
   def test_strict_properties
     schema = {
       '$schema' => 'http://json-schema.org/draft-04/schema#',
@@ -195,6 +113,91 @@ class Draft4Test < Minitest::Test
     assert(!JSON::Validator.validate(schema, data, strict: true))
     assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
     assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
+  end
+end
+
+class Draft4Test < Minitest::Test
+  def validation_errors(schema, data, options)
+    super(schema, data, version: :draft4)
+  end
+
+  def exclusive_minimum
+    { 'exclusiveMinimum' => true }
+  end
+
+  def exclusive_maximum
+    { 'exclusiveMaximum' => true }
+  end
+
+  def ipv4_format
+    'ipv4'
+  end
+
+  include ArrayValidation::ItemsTests
+  include ArrayValidation::AdditionalItemsTests
+  include ArrayValidation::UniqueItemsTests
+
+  include EnumValidation::General
+  include EnumValidation::V3_V4
+
+  include NumberValidation::MinMaxTests
+  include NumberValidation::MultipleOfTests
+
+  include ObjectValidation::AdditionalPropertiesTests
+  include ObjectValidation::PatternPropertiesTests
+
+  include StrictValidation
+  include StrictValidationV4
+
+  include StringValidation::ValueTests
+  include StringValidation::FormatTests
+
+  include TypeValidation::SimpleTypeTests
+
+  def test_required
+    # Set up the default datatype
+    schema = {
+      '$schema' => 'http://json-schema.org/draft-04/schema#',
+      'required' => ['a'],
+      'properties' => {
+        'a' => {},
+      },
+    }
+    data = {}
+
+    refute_valid schema, data
+    data['a'] = 'Hello'
+    assert_valid schema, data
+
+    schema = {
+      '$schema' => 'http://json-schema.org/draft-04/schema#',
+      'properties' => {
+        'a' => { 'type' => 'integer' },
+      },
+    }
+
+    data = {}
+    assert_valid schema, data
+  end
+
+  def test_min_properties
+    schema = { 'minProperties' => 2 }
+
+    assert_valid schema, { 'a' => 1, 'b' => 2 }
+    assert_valid schema, { 'a' => 1, 'b' => 2, 'c' => 3 }
+
+    refute_valid schema, { 'a' => 1 }
+    refute_valid schema, {}
+  end
+
+  def test_max_properties
+    schema = { 'maxProperties' => 2 }
+
+    assert_valid schema, { 'a' => 1, 'b' => 2 }
+    assert_valid schema, { 'a' => 1 }
+    assert_valid schema, {}
+
+    refute_valid schema, { 'a' => 1, 'b' => 2, 'c' => 3 }
   end
 
   def test_list_option

--- a/test/draft4_test.rb
+++ b/test/draft4_test.rb
@@ -96,15 +96,23 @@ class Draft4Test < Minitest::Test
 
     data = { 'a' => 'a' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'b' => 'b' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b' }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 'c' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
   end
 
   def test_strict_properties_additional_props
@@ -119,18 +127,28 @@ class Draft4Test < Minitest::Test
 
     data = { 'a' => 'a' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'b' => 'b' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b' }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 'c' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 3 }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
   end
 
   def test_strict_properties_pattern_props
@@ -145,24 +163,38 @@ class Draft4Test < Minitest::Test
 
     data = { 'a' => 'a' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'b' => 'b' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b' }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 'c' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 3 }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', '23 taco' => 3 }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', '23 taco' => 'cheese' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
   end
 
   def test_list_option

--- a/test/schema_validation_test.rb
+++ b/test/schema_validation_test.rb
@@ -181,4 +181,15 @@ class SchemaValidationTest < Minitest::Test
     }
     assert(JSON::Validator.validate!(symbolized_schema, data, validate_schema: true))
   end
+
+  def test_validate_schema_no_additional_properties
+    errors = JSON::Validator.fully_validate_schema(symbolized_schema, noAdditionalProperties: true)
+    assert_equal 1, errors.size
+    assert_match(/the property .* contained undefined properties: .*relationships/i, errors.first)
+
+    schema_without_additional_properties = symbolized_schema
+    schema_without_additional_properties.delete(:relationships)
+    errors = JSON::Validator.fully_validate_schema(schema_without_additional_properties, noAdditionalProperties: true)
+    assert_equal 0, errors.size
+  end
 end

--- a/test/support/strict_validation.rb
+++ b/test/support/strict_validation.rb
@@ -63,7 +63,7 @@ module StrictValidation
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 'c' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
-    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
     assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 3 }
@@ -113,7 +113,7 @@ module StrictValidation
 
     data = { 'a' => 'a', 'b' => 'b', '23 taco' => 'cheese' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
-    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
     assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
   end
 end

--- a/test/support/strict_validation.rb
+++ b/test/support/strict_validation.rb
@@ -10,15 +10,23 @@ module StrictValidation
 
     data = { 'a' => 'a' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'b' => 'b' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b' }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 'c' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
   end
 
   def test_strict_error_message
@@ -40,18 +48,28 @@ module StrictValidation
 
     data = { 'a' => 'a' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'b' => 'b' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b' }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 'c' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 3 }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
   end
 
   def test_strict_properties_pattern_props
@@ -65,23 +83,37 @@ module StrictValidation
 
     data = { 'a' => 'a' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'b' => 'b' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(!JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b' }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 'c' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', 'c' => 3 }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', '23 taco' => 3 }
     assert(JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(JSON::Validator.validate(schema, data, noAdditionalProperties: true))
 
     data = { 'a' => 'a', 'b' => 'b', '23 taco' => 'cheese' }
     assert(!JSON::Validator.validate(schema, data, strict: true))
+    assert(JSON::Validator.validate(schema, data, allPropertiesRequired: true))
+    assert(!JSON::Validator.validate(schema, data, noAdditionalProperties: true))
   end
 end


### PR DESCRIPTION
Adds the `allPropertiesRequired` and `noAdditionalProperties` options.  Each of these options include a subset of the functionality that `strict` provides.

Here is how the three options interact, as a truth table:

| `strict` | `allPropertiesRequired` | `noAdditionalProperties` | All Properties are Required | Additional Properties are not Permitted |
|------------|---------------------------|----------------------------|---------------------|-------------------------|
| T      | *                     | *                      | T                           | T                                       |
| F      | T                     | T                      | T                           | T                                       |
| F      | T                     | F                      | T                           | F                                       |
| F      | F                     | T                      | F                           | T                                       |
| F      | F                     | F                      | F                           | F                                       |

These changes are not breaking - `strict` behaves the same way that it did previously.