### PR TITLE
Handling allOf error message

### DIFF
--- a/lib/json-schema/attributes/allof.rb
+++ b/lib/json-schema/attributes/allof.rb
@@ -7,6 +7,7 @@ module JSON
         # Create an hash to hold errors that are generated during validation
         errors = Hash.new { |hsh, k| hsh[k] = [] }
         valid = true
+        message = nil
 
         current_schema.schema['allOf'].each_with_index do |element, schema_index|
           schema = JSON::Schema.new(element, current_schema.uri, validator)
@@ -17,8 +18,9 @@ module JSON
 
           begin
             schema.validate(data, fragments, processor, options)
-          rescue ValidationError
+          rescue ValidationError => e
             valid = false
+            message = e.message
           end
 
           diff = validation_errors(processor).count - pre_validation_error_count
@@ -29,7 +31,7 @@ module JSON
         end
 
         if !valid || !errors.empty?
-          message = "The property '#{build_fragment(fragments)}' of type #{type_of_data(data)} did not match all of the required schemas"
+          message ||= "The property '#{build_fragment(fragments)}' of type #{type_of_data(data)} did not match all of the required schemas"
           validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
           validation_errors(processor).last.sub_errors = errors
         end

--- a/test/all_of_ref_schema_test.rb
+++ b/test/all_of_ref_schema_test.rb
@@ -32,4 +32,21 @@ class AllOfRefSchemaTest < Minitest::Test
     - The property '#/name' of type string did not match the following type: integer"''
     assert_equal(expected_message, errors[0])
   end
+
+  def test_all_of_ref_message_with_one_attribute_wrong
+    errors = JSON::Validator.fully_validate(schema, data)
+    expected_message = ''"The property '#/' of type object did not match all of the required schemas. The schema specific errors were:
+
+- allOf #0:
+    - The property '#/name' of type string did not match the following type: integer"''
+    assert_equal(expected_message, errors[0])
+  end
+
+  def test_all_of_ref_validate_messgae
+    exception = assert_raises JSON::Schema::ValidationError do
+      JSON::Validator.validate!(schema, data)
+    end
+    expected_error_message = "The property '#/name' of type string did not match the following type: integer"
+    assert_equal expected_error_message, exception.message
+  end
 end

--- a/test/data/all_of_ref_data.json
+++ b/test/data/all_of_ref_data.json
@@ -1,3 +1,4 @@
 {
-  "name" : "john"
+  "name" : "john",
+  "id" : "1"
 }

--- a/test/schemas/all_of_ref_base_schema.json
+++ b/test/schemas/all_of_ref_base_schema.json
@@ -1,6 +1,7 @@
 {
 	"type": "object",
 	"properties" : {
-   		"name" : { "type": "integer" }
+   		"name" : { "type": "integer" },
+   		"id" : { "type": "string" }
  	}
 }


### PR DESCRIPTION
user.json

```
{
  "type": "object",
  "required": ["user"],
  "properties": {
    "user": {
      "allOf": [
        {
          "type": "object",
          "properties": {
            "name": { "type": "string" }
          }
        },
        {
          "type": "object",
          "properties": {
            "age": { "type": "integer" }
          }
        }
      ]
    }
  }
}
```
Based on the sample shared, if we are having one attribute wrong we will see a particular type message , else  default msg will be displayed.
This is to retain current behaviour.
For Example: 


```
JSON::Validator.validate!("./user.json", user: {  name: "Jhon",  age: "1"  })
op: The property '#/user/age' of type string did not match the following type: integer in schema e026eb4f-6143-5dfc-a3df-9eb1ad1d012c
```

```
JSON::Validator.validate!("./user.json", user: {  name: 1,  age: 1  })
op: JSON::Schema::ValidationError (The property '#/user' of type object did not match all of the required schemas in schema e026eb4f-6143-5dfc-a3df-9eb1ad1d012c)

```

```
JSON::Validator.validate!("./user.json", user: {  name: 1,  age: "1"  })
op: JSON::Schema::ValidationError (The property '#/user' of type object did not match all of the required schemas in schema e026eb4f-6143-5dfc-a3df-9eb1ad1d012c)
```
