### PR TITLE
Integer as string should be defined as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,19 @@ JSON::Validator.validate(schema, { "a" => 1 }, :parse_data => false)
 JSON::Validator.validate(schema, '{ "a": 1 }', :parse_data => false)
 
 #
+# with the `:parse_integer` option set to false, the integer value given as string will not be parsed.
+#
+
+# => true
+JSON::Validator.validate({type: "integer"}, "23")
+# => false
+JSON::Validator.validate({type: "integer"}, "23", parse_integer: false)
+# => true
+JSON::Validator.validate({type: "string"}, "123", parse_integer: false)
+# => false
+JSON::Validator.validate({type: "string"}, "123")
+
+#
 # with the `:json` option, the json must be an unparsed json text (not a hash, a uri or a file path)
 #
 

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -30,6 +30,7 @@ module JSON
       allPropertiesRequired: false,
       noAdditionalProperties: false,
       parse_data: true,
+      parse_integer: true
     }
     @@validators = {}
     @@default_validator = nil
@@ -44,7 +45,6 @@ module JSON
 
       configured_validator = self.class.validator_for_name(@options[:version])
       @options[:schema_reader] ||= self.class.schema_reader
-      @options[:parse_integer] = true if @options[:parse_integer].nil?
 
       @validation_options = @options[:record_errors] ? { record_errors: true } : {}
       @validation_options[:insert_defaults] = true if @options[:insert_defaults]

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -577,7 +577,8 @@ module JSON
           data = self.class.parse(custom_open(json_uri))
         elsif data.is_a?(String)
           begin
-            data = self.class.parse(data)
+            # Check if the string is valid integer
+            data = data.match?(/\A[+-]?\d+\z/) ? data : self.class.parse(data)
           rescue JSON::Schema::JsonParseError
             begin
               json_uri = Util::URI.normalized_uri(data)

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -44,6 +44,7 @@ module JSON
 
       configured_validator = self.class.validator_for_name(@options[:version])
       @options[:schema_reader] ||= self.class.schema_reader
+      @options[:parse_integer] = true if @options[:parse_integer].nil?
 
       @validation_options = @options[:record_errors] ? { record_errors: true } : {}
       @validation_options[:insert_defaults] = true if @options[:insert_defaults]
@@ -578,7 +579,8 @@ module JSON
         elsif data.is_a?(String)
           begin
             # Check if the string is valid integer
-            data = data.match?(/\A[+-]?\d+\z/) ? data : self.class.parse(data)
+            strict_convert = data.match?(/\A[+-]?\d+\z/) && !@options[:parse_integer]
+            data = strict_convert ? data : self.class.parse(data)
           rescue JSON::Schema::JsonParseError
             begin
               json_uri = Util::URI.normalized_uri(data)

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -30,7 +30,7 @@ module JSON
       allPropertiesRequired: false,
       noAdditionalProperties: false,
       parse_data: true,
-      parse_integer: true
+      parse_integer: true,
     }
     @@validators = {}
     @@default_validator = nil

--- a/test/initialize_data_test.rb
+++ b/test/initialize_data_test.rb
@@ -24,6 +24,8 @@ class InitializeDataTest < Minitest::Test
 
     refute(JSON::Validator.validate(schema, data, parse_data: false))
 
+    refute(JSON::Validator.validate(schema, data, parse_integer: false))
+
     assert(JSON::Validator.validate(schema, data, json: true))
 
     assert_raises(JSON::Schema::JsonLoadError) { JSON::Validator.validate(schema, data, uri: true) }
@@ -181,6 +183,10 @@ class InitializeDataTest < Minitest::Test
     assert(v.validate(data))
 
     v = JSON::Validator.new(schema, { parse_data: false })
+    assert_raises(JSON::Schema::ValidationError) { v.validate(data) }
+    assert_raises(JSON::Schema::ValidationError) { v.validate(data) }
+
+    v = JSON::Validator.new(schema, { parse_integer: false })
     assert_raises(JSON::Schema::ValidationError) { v.validate(data) }
     assert_raises(JSON::Schema::ValidationError) { v.validate(data) }
 


### PR DESCRIPTION
Fix for #475 

`parse_data` parses integer string also to integers. This breaks when integer string is expected to be string. To fix this, introduced new param `parse_integer` when set to false, integers are not parsed.
 
_Before_
 JSON::Validator.fully_validate({type: "string"}, "123")
=> ["The property '#/' of type integer did not match the following type: string in schema"]

_After_
 JSON::Validator.fully_validate({type: "string"}, "123", {"parse_integer" => false)
=> []