### PR TITLE
Ensure compatibility with `ruby --enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
           - ruby: "3.1"
             coverage: "yes"
           - ruby: "3.2"
+          - ruby: "3.3"
+          - ruby: "3.3"
+            rubyopt: "--enable-frozen-string-literal"
     env:
       COVERAGE: ${{ matrix.coverage }}
     steps:
@@ -37,7 +40,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run tests
-        run: bundle exec rake ${{ matrix.rake_task }}
+        run: bundle exec rake ${{ matrix.rake_task }} RUBYOPT="${{ matrix.rubyopt }}"
       - name: Build gem
         run: gem build *.gemspec
   tests:

--- a/lib/json-schema/util/uuid.rb
+++ b/lib/json-schema/util/uuid.rb
@@ -46,7 +46,7 @@ module JSON
           # nstr[7] |= 0b01010000
           nstr[8] &= 0b00111111
           nstr[8] |= 0b10000000
-          str = ''
+          str = +''
           nstr.each { |s| str << s.chr }
           str
         end


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205

`json-schema` is used by the `rbs` gem, which is tested as part of the `ruby-core` CI, and it's failing with frozen string literals are enabled by default.