### PR TITLE
Add missing require 'stringio'

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -5,6 +5,7 @@ require 'digest/sha1'
 require 'date'
 require 'thread'
 require 'timeout'
+require 'stringio'
 require 'yaml'
 
 require 'json-schema/schema/reader'


### PR DESCRIPTION
In some cases, such a statically built ruby 3.x, I definitely get `NameError: uninitialized constant IO::StringIO`