### PR TITLE
Add failing test case for ref usage

### DIFF
--- a/test/data/internal_ref_schema_data.json
+++ b/test/data/internal_ref_schema_data.json
@@ -1,0 +1,8 @@
+{
+  "top_level_attribute": false,
+  "objects_of_subtypes": {
+    "name_of_subtype": {
+      "some_attribute": "value"
+    }
+  }
+}

--- a/test/files_test.rb
+++ b/test/files_test.rb
@@ -48,4 +48,9 @@ class FilesTest < Minitest::Test
     assert_valid schema_fixture_path('good_schema_extends1.json'), { 'a' => 5 }
     assert_valid schema_fixture_path('good_schema_extends2.json'), { 'a' => 5, 'b' => { 'a' => 5 } }
   end
+
+  def test_internal_ref_schema
+    assert_valid schema_fixture_path('internal_ref_schema.json'), { 'top_level_attribute' => true }
+    assert_valid schema_fixture_path('internal_ref_schema.json'), data_fixture_path('internal_ref_schema_data.json'), uri: true
+  end
 end

--- a/test/schemas/internal_ref_schema.json
+++ b/test/schemas/internal_ref_schema.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/Toplevel",
+    "definitions": {
+        "Toplevel": {
+            "properties": {
+                "top_level_attribute": {
+                    "type": "boolean",
+                    "description": "A toplevel boolean attribute"
+                },
+                "objects_of_subtypes": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/some.Subtype",
+                        "additionalProperties": false
+                    },
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Toplevel",
+            "description": "Toplevel type with some attributes and objects of subtypes."
+        },
+        "some.Subtype": {
+            "properties": {
+                "some_attribute": {
+                    "type": "string",
+                    "description": "A string attribute for the sub type"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Subtype",
+            "description": "Subtype can be used inside toplevel."
+        }
+    }
+}


### PR DESCRIPTION
This adds a failing test for a test case extracted from a local issue with a JSON schema. This schema seems to work fine in other implementations, such as https://www.jsonschemavalidator.net which says it's valid and https://github.com/xeipuuv/gojsonschema which we also use for the same original schema (I simplified here for reproduction purposes).

I've tried further debugging why this doesn't seem to work, but have failed so far. It seems though that a failing test case is still then a useful bugreport this way.

Also happy for further dig in myself if someone has some pointers here as to where to look and what could be wrong here.