### PR TITLE
Remove VERSION.yml

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,3 +1,0 @@
-major: 4
-minor: 3
-patch: 1

--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -1,12 +1,6 @@
-require 'yaml'
-
-version_yaml = YAML.load(File.open(File.expand_path('../VERSION.yml', __FILE__)).read)
-version = "#{version_yaml['major']}.#{version_yaml['minor']}.#{version_yaml['patch']}"
-gem_name = 'json-schema'
-
 Gem::Specification.new do |s|
-  s.name = gem_name
-  s.version = version
+  s.name = 'json-schema'
+  s.version = '4.3.1'
   s.authors = ['Kenny Hoxworth', 'Vox Pupuli']
   s.email = 'voxpupuli@groups.io'
   s.homepage = 'https://github.com/voxpupuli/json-schema/'


### PR DESCRIPTION
Usually we track the version in the gemspec. This gem was a bit special and tracked it in the VERSION.yml. To keep the setup identical to our other gems, I'm removing the VERSION.yml.