### PR TITLE
Drop bundler dev dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,5 @@
-require 'bundler'
 require 'rake'
 require 'rake/testtask'
-
-Bundler::GemHelper.install_tasks
 
 desc 'Updates the json-schema common test suite to the latest version'
 task :update_common_tests do

--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -16,9 +16,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['README.md', 'LICENSE.md']
   s.required_ruby_version = '>= 2.7'
   s.license = 'MIT'
-  s.required_rubygems_version = '>= 2.5'
 
-  s.add_development_dependency 'bundler'
   s.add_development_dependency 'minitest', '~> 5.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'voxpupuli-rubocop', '~> 2.8.0'


### PR DESCRIPTION
We don't have it in the majority of our gems. To keep the setup identical, we can remove it in json-schema as well.