### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
     'source_code_uri' => s.homepage,
     'changelog_uri' => "#{s.homepage}/blob/master/CHANGELOG.md",
     'bug_tracker_uri' => "#{s.homepage}/issues",
+    'funding_uri' => 'https://github.com/sponsors/voxpupuli',
   }
   s.summary = 'Ruby JSON Schema Validator'
   s.files = Dir['lib/**/*', 'resources/*.json']


### PR DESCRIPTION
I noticed that the project already has a FUNDING.yml. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.