### PR TITLE
Add bigdecimal dependency to fix deprecation warning for Ruby 3.4

### DIFF
--- a/json-schema.gemspec
+++ b/json-schema.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock', '~> 3.23'
 
   s.add_dependency 'addressable', '~> 2.8'
+  s.add_dependency 'bigdecimal', '~> 3.1'
 end


### PR DESCRIPTION
bigdecimal will no longer be a default gem in Ruby 3.4, so Ruby 3.3 prints a warning if it is not loaded:

    /Users/jamiecobbett/.asdf/installs/ruby/3.3.6/lib/ruby/gems/3.3.0/gems/json-schema-5.1.0/lib/json-schema/validator.rb:3:
    warning: bigdecimal was loaded from the standard library, but will no longer be
    part of the default gems starting from Ruby 3.4.0.  You can add bigdecimal to
    your Gemfile or gemspec to silence this warning.

Fixing this now will pre-empt errors when trying to use the gem on Ruby 3.4+ when it is released.