### PR TITLE
failing test

### DIFF
--- a/test/no_additional_properties_all_of_test.rb
+++ b/test/no_additional_properties_all_of_test.rb
@@ -1,0 +1,41 @@
+require File.expand_path('../support/test_helper', __FILE__)
+
+class NoAdditionalPropertiesAllOfTest < Minitest::Test
+  def schema
+    {
+      '$schema': 'http://json-schema.org/draft-04/schema#',
+      type: 'object',
+      allOf: [
+        {
+          type: 'object',
+          properties: {
+            a: {
+              type: 'integer',
+            },
+          },
+          required: ['a'],
+        },
+        {
+          type: 'object',
+          properties: {
+            b: {
+              type: 'string',
+            },
+          },
+          required: ['b'],
+        },
+      ],
+    }
+  end
+
+  def data
+    {
+      a: 1,
+      b: 'hello',
+    }
+  end
+
+  def test_all_of_ref_message
+    assert_valid schema, data, { noAdditionalProperties: true }
+  end
+end


### PR DESCRIPTION
Example failing test to illustrate bug when using `noAdditionalProperties` along with `allOf`.