### PR TITLE
Require delegate library in validator

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -6,6 +6,7 @@ require 'date'
 require 'timeout'
 require 'stringio'
 require 'yaml'
+require 'delegate'
 
 require 'json-schema/schema/reader'
 require 'json-schema/errors/schema_error'


### PR DESCRIPTION
This adds a missing require for the delegate library. Previously, a `NameError` was raised as the `SimpleDelegator` class could not be found.