### PR TITLE
Improve :failed_attribute value for custom formats

### DIFF
--- a/lib/json-schema/attributes/formats/custom.rb
+++ b/lib/json-schema/attributes/formats/custom.rb
@@ -13,7 +13,7 @@ module JSON
           @validation_proc.call data
         rescue JSON::Schema::CustomFormatError => e
           message = "The property '#{self.class.build_fragment(fragments)}' #{e.message}"
-          self.class.validation_error(processor, message, fragments, current_schema, self, options[:record_errors])
+          self.class.validation_error(processor, message, fragments, current_schema, self.class, options[:record_errors])
         end
       end
     end

--- a/test/custom_format_test.rb
+++ b/test/custom_format_test.rb
@@ -96,6 +96,10 @@ class CustomFormatTest < Minitest::Test
       assert_equal(1, errors.count)
       assert_match(%r{The property '#/a' must be 42 in schema}, errors.first, "#{prefix} records format error")
 
+      errors_as_objects = JSON::Validator.fully_validate(schema, data, errors_as_objects: true)
+
+      assert_match('CustomFormat', errors_as_objects.first[:failed_attribute], "#{prefix} tags failed attribute")
+
       data['a'] = 23
       errors = JSON::Validator.fully_validate(schema, data)
 


### PR DESCRIPTION
When this failed_attribute param is parsed, it expects a class name, not an instance name. This will ensure it shows `CustomFormat` instead of `0x00009783abf73>`
<img width="750" height="69" alt="image" src="https://github.com/user-attachments/assets/e2756e90-ef10-4a62-995a-5691ce3c26a5" />
